### PR TITLE
Bugfixes, v1.2.1 release candidate

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ try {
     // Handle error
 }
 ```
-The above code will generate a time-based one-time password based on the current time. The API supports, besides the current time, the creation of codes based on `timeSince1970` in milliseconds, `Date`, and `Instant`:
+The above code will generate a time-based one-time password based on the current time. The API supports, besides the current time, the creation of codes based on `timeSince1970` in seconds, `Date`, and `Instant`:
 
 ```java
 try {
@@ -164,7 +164,7 @@ try {
     // Based on specific date
     totp.generate(new Date());
     
-    // Based on milliseconds past 1970
+    // Based on seconds past 1970
     totp.generate(9238346823);
     
     // Based on an instant

--- a/README.md
+++ b/README.md
@@ -30,23 +30,23 @@ The following features are supported:
 <dependency>
     <groupId>com.github.bastiaanjansen</groupId>
     <artifactId>otp-java</artifactId>
-    <version>1.2.0</version>
+    <version>1.2.1</version>
 </dependency>
 ```
 
 ### Gradle
 ```gradle
-implementation 'com.github.bastiaanjansen:otp-java:1.2.0'
+implementation 'com.github.bastiaanjansen:otp-java:1.2.1'
 ```
 
 ### Scala SBT
 ```scala
-libraryDependencies += "com.github.bastiaanjansen" % "otp-java" % "1.2.0"
+libraryDependencies += "com.github.bastiaanjansen" % "otp-java" % "1.2.1"
 ```
 
 ### Apache Ivy
 ```xml
-<dependency org="com.github.bastiaanjansen" name="otp-java" rev="1.2.0" />
+<dependency org="com.github.bastiaanjansen" name="otp-java" rev="1.2.1" />
 ```
 
 Or you can download the source from the [GitHub releases page](https://github.com/BastiaanJansen/OTP-Java/releases).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>com.github.bastiaanjansen</groupId>
     <artifactId>otp-java</artifactId>
-    <version>1.2.1-SNAPSHOT</version>
+    <version>1.2.1</version>
 
     <name>OTP-Java</name>
     <description>A small and easy-to-use one-time password generator for Java according to RFC 4226 (HOTP) and RFC 6238 (TOTP).</description>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>com.github.bastiaanjansen</groupId>
     <artifactId>otp-java</artifactId>
-    <version>1.2.0-SNAPSHOT</version>
+    <version>1.2.1-SNAPSHOT</version>
 
     <name>OTP-Java</name>
     <description>A small and easy-to-use one-time password generator for Java according to RFC 4226 (HOTP) and RFC 6238 (TOTP).</description>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>com.github.bastiaanjansen</groupId>
     <artifactId>otp-java</artifactId>
-    <version>1.2.1</version>
+    <version>1.2.1-SNAPSHOT</version>
 
     <name>OTP-Java</name>
     <description>A small and easy-to-use one-time password generator for Java according to RFC 4226 (HOTP) and RFC 6238 (TOTP).</description>

--- a/src/main/java/com/bastiaanjansen/otp/HOTPGenerator.java
+++ b/src/main/java/com/bastiaanjansen/otp/HOTPGenerator.java
@@ -27,6 +27,10 @@ public class HOTPGenerator extends OTPGenerator {
         super(passwordLength, algorithm, secret);
     }
 
+    private HOTPGenerator(final HOTPGenerator.Builder builder) {
+        super(builder.getPasswordLength(), builder.getAlgorithm(), builder.getSecret());
+    }
+
     /**
      * Generate a counter-based one-time password
      * @param counter how many times time interval has passed since 1970
@@ -88,7 +92,7 @@ public class HOTPGenerator extends OTPGenerator {
          */
         @Override
         public HOTPGenerator build() {
-            return new HOTPGenerator(passwordLength, algorithm, secret);
+            return new HOTPGenerator(this);
         }
 
         /**

--- a/src/main/java/com/bastiaanjansen/otp/HOTPGenerator.java
+++ b/src/main/java/com/bastiaanjansen/otp/HOTPGenerator.java
@@ -64,7 +64,7 @@ public class HOTPGenerator extends OTPGenerator {
      */
     public URI getURI(int counter, String issuer, String account) throws URISyntaxException {
         Map<String, String> query = new HashMap<>();
-        query.put("counter", String.valueOf(counter));
+        query.put(URIHelper.COUNTER, String.valueOf(counter));
 
         String path = account.isEmpty() ? issuer : String.format("%s:%s", issuer, account);
 

--- a/src/main/java/com/bastiaanjansen/otp/TOTPGenerator.java
+++ b/src/main/java/com/bastiaanjansen/otp/TOTPGenerator.java
@@ -169,7 +169,7 @@ public class TOTPGenerator extends OTPGenerator {
      * @return counter based on current time and a specific time interval
      */
     private long calculateCounter(final Duration period) {
-        return System.currentTimeMillis() / period.toMillis();
+        return calculateCounter(System.currentTimeMillis(), period);
     }
 
     /**

--- a/src/main/java/com/bastiaanjansen/otp/TOTPGenerator.java
+++ b/src/main/java/com/bastiaanjansen/otp/TOTPGenerator.java
@@ -159,7 +159,7 @@ public class TOTPGenerator extends OTPGenerator {
      * @return counter based on seconds past 1970 and time interval
      */
     private long calculateCounter(final long secondsPast1970, final Duration period) {
-        return TimeUnit.SECONDS.toMillis(secondsPast1970) / TimeUnit.SECONDS.toMillis(period.getSeconds());
+        return TimeUnit.SECONDS.toMillis(secondsPast1970) / period.toMillis();
     }
 
     /**

--- a/src/main/java/com/bastiaanjansen/otp/TOTPGenerator.java
+++ b/src/main/java/com/bastiaanjansen/otp/TOTPGenerator.java
@@ -136,7 +136,7 @@ public class TOTPGenerator extends OTPGenerator {
      */
     public URI getURI(final String issuer, final String account) throws URISyntaxException {
         Map<String, String> query = new HashMap<>();
-        query.put("period", String.valueOf(period.getSeconds()));
+        query.put(URIHelper.PERIOD, String.valueOf(period.getSeconds()));
 
         String path = account.isEmpty() ? issuer : String.format("%s:%s", issuer, account);
 

--- a/src/main/java/com/bastiaanjansen/otp/helpers/URIHelper.java
+++ b/src/main/java/com/bastiaanjansen/otp/helpers/URIHelper.java
@@ -18,6 +18,7 @@ public class URIHelper {
     public static final String SECRET = "secret";
     public static final String ALGORITHM = "algorithm";
     public static final String PERIOD = "period";
+    public static final String COUNTER = "counter";
 
     /**
      * Get a map of query items from URI

--- a/src/test/java/com/bastiaanjansen/otp/ExampleApp.java
+++ b/src/test/java/com/bastiaanjansen/otp/ExampleApp.java
@@ -17,8 +17,8 @@ public class ExampleApp {
             String code = totp.generate();
             System.out.println("Generated code: " + code);
 
-            // To verify a code
-            totp.verify(code); // true
+            // To verify a codes
+            System.out.println(totp.verify(code)); // true
         } catch (IllegalStateException e) {
             e.printStackTrace();
         }

--- a/src/test/java/com/bastiaanjansen/otp/TOTPGeneratorTest.java
+++ b/src/test/java/com/bastiaanjansen/otp/TOTPGeneratorTest.java
@@ -33,7 +33,7 @@ class TOTPGeneratorTest {
     @Test
     void generateWithInstant() {
         TOTPGenerator generator = new TOTPGenerator(6, Duration.ofSeconds(30), HMACAlgorithm.SHA1, secret);
-        assertEquals("455216", generator.generate(Instant.ofEpochMilli(1)));
+        assertEquals("455216", generator.generate(Instant.ofEpochSecond(1)));
     }
 
     @Test
@@ -47,6 +47,13 @@ class TOTPGeneratorTest {
     void generateWithCustomTimeInterval() {
         TOTPGenerator generator = new TOTPGenerator(6, Duration.ofSeconds(60), HMACAlgorithm.SHA1, secret);
         assertEquals("455216", generator.generate(1));
+    }
+
+    @Test
+    void generateWithPeriodOfZero() {
+        assertThrows(IllegalArgumentException.class, () -> {
+            new TOTPGenerator(6, Duration.ofSeconds(0), HMACAlgorithm.SHA1, secret);
+        });
     }
 
     @Test


### PR DESCRIPTION
1. Fixed bug regarding generating TOTP tokens with `Instants`.
2. Periods of less than one second are not allowed and will now throw an `IllegalArgumentException`.