### PR TITLE
Add issuer parameter to uri + encode url parameters

### DIFF
--- a/src/main/java/com/bastiaanjansen/otp/OTP.java
+++ b/src/main/java/com/bastiaanjansen/otp/OTP.java
@@ -140,6 +140,7 @@ class OTP {
         query.put(URIHelper.DIGITS, String.valueOf(passwordLength));
         query.put(URIHelper.ALGORITHM, algorithm.name());
         query.put(URIHelper.SECRET, new String(secret, StandardCharsets.UTF_8));
+        query.put(URIHelper.ISSUER, issuer);
 
         String path = account.isEmpty() ? issuer : String.format("%s:%s", issuer, account);
 

--- a/src/main/java/com/bastiaanjansen/otp/helpers/URIHelper.java
+++ b/src/main/java/com/bastiaanjansen/otp/helpers/URIHelper.java
@@ -14,15 +14,15 @@ import java.util.Map;
  * @author Bastiaan Jansen
  */
 public class URIHelper {
-
-    private URIHelper() {}
-
+    
     public static final String DIGITS = "digits";
     public static final String SECRET = "secret";
     public static final String ALGORITHM = "algorithm";
     public static final String PERIOD = "period";
     public static final String COUNTER = "counter";
     public static final String ISSUER = "issuer";
+
+    private URIHelper() {}
 
     /**
      * Get a map of query items from URI
@@ -67,7 +67,7 @@ public class URIHelper {
             for (int i = 0; i < queryKeys.length; i++) {
                 String sign = i == 0 ? "?" : "&";
                 String key = queryKeys[i];
-                    uriString.append(String.format("%s%s=%s", sign, key, URLEncoder.encode(query.get(key), "UTF-8")));
+                uriString.append(String.format("%s%s=%s", sign, key, URLEncoder.encode(query.get(key), "UTF-8")));
             }
         } catch (UnsupportedEncodingException e) {
             // Highly unlikely

--- a/src/main/java/com/bastiaanjansen/otp/helpers/URIHelper.java
+++ b/src/main/java/com/bastiaanjansen/otp/helpers/URIHelper.java
@@ -39,8 +39,8 @@ public class URIHelper {
             int index = pair.indexOf("=");
             try {
                 items.put(
-                        URLDecoder.decode(pair.substring(0, index), "UTF-8"),
-                        URLDecoder.decode(pair.substring(index + 1), "UTF-8")
+                        URLDecoder.decode(pair.substring(0, index), StandardCharsets.UTF_8.toString()),
+                        URLDecoder.decode(pair.substring(index + 1), StandardCharsets.UTF_8.toString())
                 );
             } catch (UnsupportedEncodingException e) {
                 throw new IllegalStateException("Encoding should be supported");
@@ -67,7 +67,7 @@ public class URIHelper {
             for (int i = 0; i < queryKeys.length; i++) {
                 String sign = i == 0 ? "?" : "&";
                 String key = queryKeys[i];
-                uriString.append(String.format("%s%s=%s", sign, key, URLEncoder.encode(query.get(key), "UTF-8")));
+                uriString.append(String.format("%s%s=%s", sign, key, URLEncoder.encode(query.get(key), StandardCharsets.UTF_8.toString())));
             }
         } catch (UnsupportedEncodingException e) {
             // Highly unlikely

--- a/src/main/java/com/bastiaanjansen/otp/helpers/URIHelper.java
+++ b/src/main/java/com/bastiaanjansen/otp/helpers/URIHelper.java
@@ -21,6 +21,7 @@ public class URIHelper {
     public static final String ALGORITHM = "algorithm";
     public static final String PERIOD = "period";
     public static final String COUNTER = "counter";
+    public static final String ISSUER = "issuer";
 
     /**
      * Get a map of query items from URI

--- a/src/main/java/com/bastiaanjansen/otp/helpers/URIHelper.java
+++ b/src/main/java/com/bastiaanjansen/otp/helpers/URIHelper.java
@@ -4,6 +4,7 @@ import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URLDecoder;
+import java.net.URLEncoder;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -62,10 +63,15 @@ public class URIHelper {
         StringBuilder uriString = new StringBuilder(String.format("%s://%s/%s", scheme, host, path));
         String[] queryKeys = query.keySet().toArray(new String[0]);
 
-        for (int i = 0; i < queryKeys.length; i++) {
-            String sign = i == 0 ? "?" : "&";
-            String key = queryKeys[i];
-            uriString.append(String.format("%s%s=%s", sign, key, query.get(key)));
+        try {
+            for (int i = 0; i < queryKeys.length; i++) {
+                String sign = i == 0 ? "?" : "&";
+                String key = queryKeys[i];
+                    uriString.append(String.format("%s%s=%s", sign, key, URLEncoder.encode(query.get(key), "UTF-8")));
+            }
+        } catch (UnsupportedEncodingException e) {
+            // Highly unlikely
+            throw new IllegalArgumentException(e);
         }
 
         return new URI(uriString.toString());

--- a/src/test/java/com/bastiaanjansen/otp/HOTPTest.java
+++ b/src/test/java/com/bastiaanjansen/otp/HOTPTest.java
@@ -125,7 +125,7 @@ class HOTPTest {
         HOTP generator = new HOTP.Builder(secret.getBytes()).build();
         URI uri = generator.getURI(10, "issuer");
 
-        assertThat( uri.toString(), is("otpauth://hotp/issuer?digits=6&counter=10&secret=" + secret + "&issuer=issuer&algorithm=SHA1"));
+        assertThat(uri.toString(), is("otpauth://hotp/issuer?digits=6&counter=10&secret=" + secret + "&issuer=issuer&algorithm=SHA1"));
     }
 
     @Test
@@ -133,7 +133,7 @@ class HOTPTest {
         HOTP generator = new HOTP.Builder(secret.getBytes()).build();
         URI uri = generator.getURI(10, "mac&cheese");
 
-        assertThat( uri.toString(), is("otpauth://hotp/mac&cheese?digits=6&counter=10&secret=" + secret + "&issuer=mac%26cheese&algorithm=SHA1"));
+        assertThat(uri.toString(), is("otpauth://hotp/mac&cheese?digits=6&counter=10&secret=" + secret + "&issuer=mac%26cheese&algorithm=SHA1"));
     }
 
 

--- a/src/test/java/com/bastiaanjansen/otp/HOTPTest.java
+++ b/src/test/java/com/bastiaanjansen/otp/HOTPTest.java
@@ -125,7 +125,7 @@ class HOTPTest {
         HOTP generator = new HOTP.Builder(secret.getBytes()).build();
         URI uri = generator.getURI(10, "issuer");
 
-        assertThat( uri.toString(), is("otpauth://hotp/issuer?digits=6&counter=10&secret=" + secret + "&algorithm=SHA1"));
+        assertThat( uri.toString(), is("otpauth://hotp/issuer?digits=6&counter=10&secret=" + secret + "&issuer=issuer&algorithm=SHA1"));
     }
 
     @Test
@@ -142,7 +142,7 @@ class HOTPTest {
         HOTP generator = new HOTP.Builder(secret.getBytes()).build();
 
         URI uri = generator.getURI(100, "issuer", "account");
-        assertThat(uri.toString(), is("otpauth://hotp/issuer:account?digits=6&counter=100&secret=" + secret + "&algorithm=SHA1"));
+        assertThat(uri.toString(), is("otpauth://hotp/issuer:account?digits=6&counter=100&secret=" + secret + "&issuer=issuer&algorithm=SHA1"));
     }
 
     @Test

--- a/src/test/java/com/bastiaanjansen/otp/HOTPTest.java
+++ b/src/test/java/com/bastiaanjansen/otp/HOTPTest.java
@@ -129,6 +129,15 @@ class HOTPTest {
     }
 
     @Test
+    void getURIWithIssuerWithUrlUnsafeCharacters() throws URISyntaxException {
+        HOTP generator = new HOTP.Builder(secret.getBytes()).build();
+        URI uri = generator.getURI(10, "mac&cheese");
+
+        assertThat( uri.toString(), is("otpauth://hotp/mac&cheese?digits=6&counter=10&secret=" + secret + "&issuer=mac%26cheese&algorithm=SHA1"));
+    }
+
+
+    @Test
     void getURIWithIssuerAndAccount_doesNotThrow() {
         HOTP generator = new HOTP.Builder(secret.getBytes()).build();
 
@@ -143,6 +152,14 @@ class HOTPTest {
 
         URI uri = generator.getURI(100, "issuer", "account");
         assertThat(uri.toString(), is("otpauth://hotp/issuer:account?digits=6&counter=100&secret=" + secret + "&issuer=issuer&algorithm=SHA1"));
+    }
+
+    @Test
+    void getURIWithIssuerAndAccountWithUrlUnsafeCharacters() throws URISyntaxException {
+        HOTP generator = new HOTP.Builder(secret.getBytes()).build();
+
+        URI uri = generator.getURI(100, "mac&cheese", "ac@cou.nt");
+        assertThat(uri.toString(), is("otpauth://hotp/mac&cheese:ac@cou.nt?digits=6&counter=100&secret=" + secret + "&issuer=mac%26cheese&algorithm=SHA1"));
     }
 
     @Test

--- a/src/test/java/com/bastiaanjansen/otp/TOTPTest.java
+++ b/src/test/java/com/bastiaanjansen/otp/TOTPTest.java
@@ -193,7 +193,7 @@ class TOTPTest {
         TOTP generator = new TOTP.Builder(secret.getBytes()).build();
 
         URI uri = generator.getURI("issuer");
-        assertThat(uri.toString(), is("otpauth://totp/issuer?period=30&digits=6&secret=" + secret + "&algorithm=SHA1"));
+        assertThat(uri.toString(), is("otpauth://totp/issuer?period=30&digits=6&secret=" + secret + "&issuer=issuer&algorithm=SHA1"));
     }
 
     @Test
@@ -211,7 +211,7 @@ class TOTPTest {
 
 
         URI uri = generator.getURI("issuer", "account");
-        assertThat(uri.toString(), is("otpauth://totp/issuer:account?period=30&digits=6&secret=" + secret + "&algorithm=SHA1"));
+        assertThat(uri.toString(), is("otpauth://totp/issuer:account?period=30&digits=6&secret=" + secret + "&issuer=issuer&algorithm=SHA1"));
     }
 
     @Test

--- a/src/test/java/com/bastiaanjansen/otp/TOTPTest.java
+++ b/src/test/java/com/bastiaanjansen/otp/TOTPTest.java
@@ -197,6 +197,14 @@ class TOTPTest {
     }
 
     @Test
+    void getURIWithIssuerWithUrlUnsafeCharacters() throws URISyntaxException {
+        TOTP generator = new TOTP.Builder(secret.getBytes()).build();
+
+        URI uri = generator.getURI("mac&cheese");
+        assertThat(uri.toString(), is("otpauth://totp/mac&cheese?period=30&digits=6&secret=" + secret + "&issuer=mac%26cheese&algorithm=SHA1"));
+    }
+
+    @Test
     void getURIWithIssuerAndAccount_doesNotThrow() {
         TOTP generator = new TOTP.Builder(secret.getBytes()).build();
 
@@ -212,6 +220,15 @@ class TOTPTest {
 
         URI uri = generator.getURI("issuer", "account");
         assertThat(uri.toString(), is("otpauth://totp/issuer:account?period=30&digits=6&secret=" + secret + "&issuer=issuer&algorithm=SHA1"));
+    }
+
+    @Test
+    void getURIWithIssuerAndAccountWithUrlUnsafeCharacters() throws URISyntaxException {
+        TOTP generator = new TOTP.Builder(secret.getBytes()).build();
+
+
+        URI uri = generator.getURI("mac&cheese", "ac@cou.nt");
+        assertThat(uri.toString(), is("otpauth://totp/mac&cheese:ac@cou.nt?period=30&digits=6&secret=" + secret + "&issuer=mac%26cheese&algorithm=SHA1"));
     }
 
     @Test

--- a/src/test/java/com/bastiaanjansen/otp/helpers/URIHelperTest.java
+++ b/src/test/java/com/bastiaanjansen/otp/helpers/URIHelperTest.java
@@ -58,4 +58,15 @@ class URIHelperTest {
 
         assertThat(uri.toString(), is(expected));
     }
+
+    @Test
+    void createURIWithUrlUnsafeCharacters() throws URISyntaxException {
+        Map<String, String> query = new HashMap<>();
+        query.put("test", "value 1");
+        query.put("test2", "value?&2");
+        URI uri = URIHelper.createURI("scheme", "host", "path", query);
+        String expected = "scheme://host/path?test2=value%3F%262&test=value+1";
+
+        assertThat(uri.toString(), is(expected));
+    }
 }


### PR DESCRIPTION
The generated URI did not contain the `issuer` parameter, as recommended per
https://github.com/google/google-authenticator/wiki/Key-Uri-Format
https://docs.yubico.com/yesdk/users-manual/application-oath/uri-string-format.html

This pull requests add it
It also ensures that URL query parameters are encoded propertly