### PR TITLE
Add a String secret Builder constructor + Base32 docs and comments #83

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Or you can download the source from the [GitHub releases page](https://github.co
 To create a `HOTPGenerator` instance, use the `HOTPGenerator.Builder` class as follows:
 
 ```java
-byte[] secret = "VV3KOX7UQJ4KYAKOHMZPPH3US4CJIMH6F3ZKNB5C2OOBQ6V2KIYHM27Q".getBytes();
+String secret = "VV3KOX7UQJ4KYAKOHMZPPH3US4CJIMH6F3ZKNB5C2OOBQ6V2KIYHM27Q";
 HOTPGenerator hotp = new HOTPGenerator.Builder(secret).build();
 ```
 The above builder creates a HOTP instance with default values for passwordLength = 6 and algorithm = SHA1. Use the builder to change these defaults:
@@ -68,12 +68,20 @@ HOTPGenerator hotp = new HOTPGenerator.Builder(secret)
         .build();
 ```
 
+If you have a shared secret described in [RFC-4226](https://www.rfc-editor.org/rfc/rfc4226), you need to encode it first:
+
+```java
+byte[] sharedSecret = getMySharedSecret();
+
+byte[] secret = Base32.encode(sharedSecret);
+```
+
 When you don't already have a secret, you can let the library generate it:
 ```java
-// To generate a secret with 160 bits
+// To generate a Base32-encoded secret with 160 bits
 byte[] secret = SecretGenerator.generate();
 
-// To generate a secret with a custom amount of bits
+// To generate a Base32-encoded secret with a custom amount of bits
 byte[] secret = SecretGenerator.generate(512);
 ```
 
@@ -131,7 +139,6 @@ TOTPGenerator totpGenerator = TOTPGenerator.fromURI(uri);
 
 Get information about the generator:
 ```java
-byte[] secret = totpGenerator.getSecret();
 int passwordLength = totpGenerator.getPasswordLength(); // 6
 HMACAlgorithm algorithm = totpGenerator.getAlgorithm(); // HMACAlgorithm.SHA1
 Duration period = totpGenerator.getPeriod(); // Duration.ofSeconds(30)

--- a/src/main/java/com/bastiaanjansen/otp/TOTPGenerator.java
+++ b/src/main/java/com/bastiaanjansen/otp/TOTPGenerator.java
@@ -12,6 +12,8 @@ import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 public final class TOTPGenerator {
     private static final String OTP_TYPE = "totp";
     private static final Duration DEFAULT_PERIOD = Duration.ofSeconds(30);
@@ -32,8 +34,7 @@ public final class TOTPGenerator {
     public static TOTPGenerator fromURI(URI uri) throws URISyntaxException {
         Map<String, String> query = URIHelper.queryItems(uri);
 
-        byte[] secret = Optional.ofNullable(query.get(URIHelper.SECRET))
-                .map(String::getBytes)
+        String secret = Optional.ofNullable(query.get(URIHelper.SECRET))
                 .orElseThrow(() -> new IllegalArgumentException("Secret query parameter must be set"));
 
         Builder builder = new Builder(secret);
@@ -171,10 +172,27 @@ public final class TOTPGenerator {
 
         private final HOTPGenerator.Builder hotpBuilder;
 
+        /**
+         * Creates a new builder.
+         * <p>
+         * Use {@link SecretGenerator#generate()} to create a secret.
+         * <p>
+         * If you are using a shared secret from another generator, you would likely need to encode it using
+         * {@link org.apache.commons.codec.binary.Base32#encode(byte[])}}
+         *
+         * @param secret Base32 encoded secret
+         */
         public Builder(byte[] secret) {
             this.period = DEFAULT_PERIOD;
             this.clock = DEFAULT_CLOCK;
             this.hotpBuilder = new HOTPGenerator.Builder(secret);
+        }
+
+        /**
+         * @param secret Base32 encoded secret
+         */
+        public Builder(String secret) {
+            this(secret.getBytes(UTF_8));
         }
 
         public Builder withHOTPGenerator(Consumer<HOTPGenerator.Builder> builder) {

--- a/src/test/java/com/bastiaanjansen/otp/HOTPGeneratorTest.java
+++ b/src/test/java/com/bastiaanjansen/otp/HOTPGeneratorTest.java
@@ -41,7 +41,7 @@ class HOTPGeneratorTest {
     @ParameterizedTest
     @MethodSource("testData")
     void generateWithCounter(int passwordLength, long counter, HMACAlgorithm algorithm, String otp) {
-        HOTPGenerator generator = new HOTPGenerator.Builder(secret.getBytes())
+        HOTPGenerator generator = new HOTPGenerator.Builder(secret)
                 .withPasswordLength(passwordLength)
                 .withAlgorithm(algorithm)
                 .build();
@@ -52,14 +52,14 @@ class HOTPGeneratorTest {
     @ParameterizedTest
     @ValueSource(ints = {-1, -100})
     void generateWithInvalidCounter_throwsIllegalArgumentException(long counter) {
-        HOTPGenerator generator = new HOTPGenerator.Builder(secret.getBytes()).build();
+        HOTPGenerator generator = new HOTPGenerator.Builder(secret).build();
 
         assertThrows(IllegalArgumentException.class, () -> generator.generate(counter));
     }
 
     @Test
     void verifyCurrentCode_true() {
-        HOTPGenerator generator = new HOTPGenerator.Builder(secret.getBytes()).build();
+        HOTPGenerator generator = new HOTPGenerator.Builder(secret).build();
         String code = generator.generate(1);
 
         assertThat(generator.verify(code, 1), is(true));
@@ -67,7 +67,7 @@ class HOTPGeneratorTest {
 
     @Test
     void verifyOlderCodeWithDelayWindowIs0_false() {
-        HOTPGenerator generator = new HOTPGenerator.Builder(secret.getBytes()).build();
+        HOTPGenerator generator = new HOTPGenerator.Builder(secret).build();
         String code = generator.generate(1);
 
         assertThat(generator.verify(code, 2), is(false));
@@ -75,7 +75,7 @@ class HOTPGeneratorTest {
 
     @Test
     void verifyOlderCodeWithDelayWindowIs1_true() {
-        HOTPGenerator generator = new HOTPGenerator.Builder(secret.getBytes()).build();
+        HOTPGenerator generator = new HOTPGenerator.Builder(secret).build();
         String code = generator.generate(1);
 
         assertThat(generator.verify(code, 2, 1), is(true));
@@ -99,7 +99,7 @@ class HOTPGeneratorTest {
 
     @Test
     void getURIWithIssuer_doesNotThrow() {
-        HOTPGenerator generator = new HOTPGenerator.Builder(secret.getBytes()).build();
+        HOTPGenerator generator = new HOTPGenerator.Builder(secret).build();
 
         assertDoesNotThrow(() -> {
            generator.getURI(10, "issuer");
@@ -108,14 +108,14 @@ class HOTPGeneratorTest {
 
     @Test
     void getURIWithIssuerWithSpace_doesNotThrow() {
-        HOTPGenerator generator = new HOTPGenerator.Builder(secret.getBytes()).build();
+        HOTPGenerator generator = new HOTPGenerator.Builder(secret).build();
 
         assertDoesNotThrow(() -> generator.getURI(10, "issuer with space"));
     }
 
     @Test
     void getURIWithIssuerWithSpace_doesEscapeIssuer() throws URISyntaxException {
-        HOTPGenerator generator = new HOTPGenerator.Builder(secret.getBytes()).build();
+        HOTPGenerator generator = new HOTPGenerator.Builder(secret).build();
 
         String url = generator.getURI(10, "issuer with space").toString();
 
@@ -124,7 +124,7 @@ class HOTPGeneratorTest {
 
     @Test
     void getURIWithIssuer() throws URISyntaxException {
-        HOTPGenerator generator = new HOTPGenerator.Builder(secret.getBytes()).build();
+        HOTPGenerator generator = new HOTPGenerator.Builder(secret).build();
         URI uri = generator.getURI(10, "issuer");
 
         assertThat(uri.toString(), is("otpauth://hotp/issuer?digits=6&counter=10&secret=" + secret + "&issuer=issuer&algorithm=SHA1"));
@@ -132,7 +132,7 @@ class HOTPGeneratorTest {
 
     @Test
     void getURIWithIssuerWithUrlUnsafeCharacters() throws URISyntaxException {
-        HOTPGenerator generator = new HOTPGenerator.Builder(secret.getBytes()).build();
+        HOTPGenerator generator = new HOTPGenerator.Builder(secret).build();
         URI uri = generator.getURI(10, "mac&cheese");
 
         assertThat(uri.toString(), is("otpauth://hotp/mac%26cheese?digits=6&counter=10&secret=" + secret + "&issuer=mac%26cheese&algorithm=SHA1"));
@@ -141,7 +141,7 @@ class HOTPGeneratorTest {
 
     @Test
     void getURIWithIssuerAndAccount_doesNotThrow() {
-        HOTPGenerator generator = new HOTPGenerator.Builder(secret.getBytes()).build();
+        HOTPGenerator generator = new HOTPGenerator.Builder(secret).build();
 
         assertDoesNotThrow(() -> {
             generator.getURI(100, "issuer", "account");
@@ -150,7 +150,7 @@ class HOTPGeneratorTest {
 
     @Test
     void getURIWithIssuerAndAccount() throws URISyntaxException {
-        HOTPGenerator generator = new HOTPGenerator.Builder(secret.getBytes()).build();
+        HOTPGenerator generator = new HOTPGenerator.Builder(secret).build();
 
         URI uri = generator.getURI(100, "issuer", "account");
         assertThat(uri.toString(), is("otpauth://hotp/issuer:account?digits=6&counter=100&secret=" + secret + "&issuer=issuer&algorithm=SHA1"));
@@ -158,7 +158,7 @@ class HOTPGeneratorTest {
 
     @Test
     void getURIWithIssuerAndAccountWithUrlUnsafeCharacters() throws URISyntaxException {
-        HOTPGenerator generator = new HOTPGenerator.Builder(secret.getBytes()).build();
+        HOTPGenerator generator = new HOTPGenerator.Builder(secret).build();
 
         URI uri = generator.getURI(100, "mac&cheese", "ac@cou.nt");
 
@@ -224,20 +224,20 @@ class HOTPGeneratorTest {
         @Test
         void builderWithPasswordLengthIs5_throwsIllegalArgumentException() {
             assertThrows(IllegalArgumentException.class, () -> {
-                new HOTPGenerator.Builder(secret.getBytes()).withPasswordLength(5).build();
+                new HOTPGenerator.Builder(secret).withPasswordLength(5).build();
             });
         }
 
         @Test
         void builderWithPasswordLengthIs9_throwsIllegalArgumentException() {
             assertThrows(IllegalArgumentException.class, () -> {
-                new HOTPGenerator.Builder(secret.getBytes()).withPasswordLength(9).build();
+                new HOTPGenerator.Builder(secret).withPasswordLength(9).build();
             });
         }
 
         @Test
         void builderWithPasswordLengthIs6() {
-            HOTPGenerator generator = new HOTPGenerator.Builder(secret.getBytes()).withPasswordLength(6).build();
+            HOTPGenerator generator = new HOTPGenerator.Builder(secret).withPasswordLength(6).build();
             int expected = 6;
 
             assertThat(generator.getPasswordLength(), Matchers.is(expected));
@@ -245,7 +245,7 @@ class HOTPGeneratorTest {
 
         @Test
         void builderWithAlgorithmSHA1() {
-            HOTPGenerator generator = new HOTPGenerator.Builder(secret.getBytes()).withAlgorithm(HMACAlgorithm.SHA1).build();
+            HOTPGenerator generator = new HOTPGenerator.Builder(secret).withAlgorithm(HMACAlgorithm.SHA1).build();
             HMACAlgorithm expected = HMACAlgorithm.SHA1;
 
             assertThat(generator.getAlgorithm(), Matchers.is(expected));
@@ -253,7 +253,7 @@ class HOTPGeneratorTest {
 
         @Test
         void builderWithAlgorithmSHA256() {
-            HOTPGenerator generator = new HOTPGenerator.Builder(secret.getBytes()).withAlgorithm(HMACAlgorithm.SHA256).build();
+            HOTPGenerator generator = new HOTPGenerator.Builder(secret).withAlgorithm(HMACAlgorithm.SHA256).build();
             HMACAlgorithm expected = HMACAlgorithm.SHA256;
 
             assertThat(generator.getAlgorithm(), Matchers.is(expected));
@@ -261,7 +261,7 @@ class HOTPGeneratorTest {
 
         @Test
         void builderWithAlgorithmSHA512() {
-            HOTPGenerator generator = new HOTPGenerator.Builder(secret.getBytes()).withAlgorithm(HMACAlgorithm.SHA512).build();
+            HOTPGenerator generator = new HOTPGenerator.Builder(secret).withAlgorithm(HMACAlgorithm.SHA512).build();
             HMACAlgorithm expected = HMACAlgorithm.SHA512;
 
             assertThat(generator.getAlgorithm(), Matchers.is(expected));
@@ -270,12 +270,12 @@ class HOTPGeneratorTest {
         @ParameterizedTest
         @ValueSource(ints = { 1, 2, 3, 4, 5, 9, 10 })
         void builderWithInvalidPasswordLength_throwsIllegalArgumentException(int passwordLength) {
-            assertThrows(IllegalArgumentException.class, () -> new HOTPGenerator.Builder(secret.getBytes()).withPasswordLength(passwordLength).build());
+            assertThrows(IllegalArgumentException.class, () -> new HOTPGenerator.Builder(secret).withPasswordLength(passwordLength).build());
         }
 
         @Test
         void builderWithoutAlgorithm_defaultAlgorithm() {
-            HOTPGenerator generator = new HOTPGenerator.Builder(secret.getBytes()).build();
+            HOTPGenerator generator = new HOTPGenerator.Builder(secret).build();
             HMACAlgorithm expected = HMACAlgorithm.SHA1;
 
             assertThat(generator.getAlgorithm(), is(expected));

--- a/src/test/java/com/bastiaanjansen/otp/TOTPGeneratorTest.java
+++ b/src/test/java/com/bastiaanjansen/otp/TOTPGeneratorTest.java
@@ -18,9 +18,9 @@ import java.util.Date;
 import java.util.stream.Stream;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class TOTPGeneratorTest {
 
@@ -74,7 +74,7 @@ class TOTPGeneratorTest {
     @ParameterizedTest
     @MethodSource("secondsPast1970TestData")
     void generateAtSecondsPast1970(int passwordLength, int secondsPast1970, HMACAlgorithm algorithm, String otp) {
-        TOTPGenerator generator = new TOTPGenerator.Builder(secret.getBytes()).withHOTPGenerator(builder -> {
+        TOTPGenerator generator = new TOTPGenerator.Builder(secret).withHOTPGenerator(builder -> {
             builder.withPasswordLength(passwordLength);
             builder.withAlgorithm(algorithm);
         }).build();
@@ -85,7 +85,7 @@ class TOTPGeneratorTest {
     @ParameterizedTest
     @MethodSource("instantTestData")
     void generateAtInstant(int passwordLength, Instant instant, HMACAlgorithm algorithm, String otp) {
-        TOTPGenerator generator = new TOTPGenerator.Builder(secret.getBytes()).withHOTPGenerator(builder -> {
+        TOTPGenerator generator = new TOTPGenerator.Builder(secret).withHOTPGenerator(builder -> {
             builder.withPasswordLength(passwordLength);
             builder.withAlgorithm(algorithm);
         }).build();
@@ -96,7 +96,7 @@ class TOTPGeneratorTest {
     @ParameterizedTest
     @MethodSource("dateTestData")
     void generateAtDate(int passwordLength, Date date, HMACAlgorithm algorithm, String otp) {
-        TOTPGenerator generator = new TOTPGenerator.Builder(secret.getBytes()).withHOTPGenerator(builder -> {
+        TOTPGenerator generator = new TOTPGenerator.Builder(secret).withHOTPGenerator(builder -> {
             builder.withPasswordLength(passwordLength);
             builder.withAlgorithm(algorithm);
         }).build();
@@ -107,7 +107,7 @@ class TOTPGeneratorTest {
     @ParameterizedTest
     @MethodSource("clockTestData")
     void generateAtNow(int passwordLength, Clock clock, HMACAlgorithm algorithm, String otp) {
-        TOTPGenerator generator = new TOTPGenerator.Builder(secret.getBytes()).withHOTPGenerator(builder -> {
+        TOTPGenerator generator = new TOTPGenerator.Builder(secret).withHOTPGenerator(builder -> {
                     builder.withPasswordLength(passwordLength);
                     builder.withAlgorithm(algorithm);
                 })
@@ -121,7 +121,7 @@ class TOTPGeneratorTest {
     @ParameterizedTest
     @ValueSource(ints = {0, -1})
     void generateWithInvalidSecondsPast1970_throwsIllegalArgumentException(int secondsPast1970) {
-        TOTPGenerator generator = new TOTPGenerator.Builder(secret.getBytes()).build();
+        TOTPGenerator generator = new TOTPGenerator.Builder(secret).build();
 
         assertThrows(IllegalArgumentException.class, () -> generator.at(secondsPast1970));
     }
@@ -129,7 +129,7 @@ class TOTPGeneratorTest {
 
     @Test
     void verifyCurrentCode_true() {
-        TOTPGenerator generator = new TOTPGenerator.Builder(secret.getBytes()).build();
+        TOTPGenerator generator = new TOTPGenerator.Builder(secret).build();
         String code = generator.now();
 
         assertThat(generator.verify(code), is(true));
@@ -137,7 +137,7 @@ class TOTPGeneratorTest {
 
     @Test
     void verifyOlderCodeWithDelayWindowIs0_false() {
-        TOTPGenerator generator = new TOTPGenerator.Builder(secret.getBytes()).build();
+        TOTPGenerator generator = new TOTPGenerator.Builder(secret).build();
         String code = generator.at(Instant.now().minusSeconds(30));
 
         assertThat(generator.verify(code), is(false));
@@ -145,7 +145,7 @@ class TOTPGeneratorTest {
 
     @Test
     void verifyOlderCodeWithDelayWindowIs1_true() {
-        TOTPGenerator generator = new TOTPGenerator.Builder(secret.getBytes()).build();
+        TOTPGenerator generator = new TOTPGenerator.Builder(secret).build();
         String code = generator.at(Instant.now().minusSeconds(30));
 
         assertThat(generator.verify(code, 1), is(true));
@@ -154,7 +154,7 @@ class TOTPGeneratorTest {
 
     @Test
     void getURIWithIssuer() throws URISyntaxException {
-        TOTPGenerator generator = new TOTPGenerator.Builder(secret.getBytes()).build();
+        TOTPGenerator generator = new TOTPGenerator.Builder(secret).build();
 
         URI uri = generator.getURI("issuer");
         assertThat(uri.toString(), is("otpauth://totp/issuer?period=30&digits=6&secret=" + secret + "&issuer=issuer&algorithm=SHA1"));
@@ -162,7 +162,7 @@ class TOTPGeneratorTest {
 
     @Test
     void getURIWithIssuerWithUrlUnsafeCharacters() throws URISyntaxException {
-        TOTPGenerator generator = new TOTPGenerator.Builder(secret.getBytes()).build();
+        TOTPGenerator generator = new TOTPGenerator.Builder(secret).build();
 
         URI uri = generator.getURI("mac&cheese");
         assertThat(uri.toString(), is("otpauth://totp/mac%26cheese?period=30&digits=6&secret=" + secret + "&issuer=mac%26cheese&algorithm=SHA1"));
@@ -170,7 +170,7 @@ class TOTPGeneratorTest {
 
     @Test
     void getURIWithIssuerAndAccount_doesNotThrow() {
-        TOTPGenerator generator = new TOTPGenerator.Builder(secret.getBytes()).build();
+        TOTPGenerator generator = new TOTPGenerator.Builder(secret).build();
 
         assertDoesNotThrow(() -> {
             generator.getURI("issuer", "account");
@@ -179,7 +179,7 @@ class TOTPGeneratorTest {
 
     @Test
     void getURIWithIssuerAndAccount() throws URISyntaxException {
-        TOTPGenerator generator = new TOTPGenerator.Builder(secret.getBytes()).build();
+        TOTPGenerator generator = new TOTPGenerator.Builder(secret).build();
 
 
         URI uri = generator.getURI("issuer", "account");
@@ -188,7 +188,7 @@ class TOTPGeneratorTest {
 
     @Test
     void getURIWithIssuerAndAccountWithUrlUnsafeCharacters() throws URISyntaxException {
-        TOTPGenerator generator = new TOTPGenerator.Builder(secret.getBytes()).build();
+        TOTPGenerator generator = new TOTPGenerator.Builder(secret).build();
 
 
         URI uri = generator.getURI("mac&cheese", "ac@cou.nt");
@@ -287,20 +287,20 @@ class TOTPGeneratorTest {
         @Test
         void builderWithPasswordLengthIs5_throwsIllegalArgumentException() {
             assertThrows(IllegalArgumentException.class, () -> {
-                new TOTPGenerator.Builder(secret.getBytes()).withHOTPGenerator(builder -> builder.withPasswordLength(5)).build();
+                new TOTPGenerator.Builder(secret).withHOTPGenerator(builder -> builder.withPasswordLength(5)).build();
             });
         }
 
         @Test
         void builderWithPasswordLengthIs9_throwsIllegalArgumentException() {
             assertThrows(IllegalArgumentException.class, () -> {
-                new TOTPGenerator.Builder(secret.getBytes()).withHOTPGenerator(builder -> builder.withPasswordLength(9)).build();
+                new TOTPGenerator.Builder(secret).withHOTPGenerator(builder -> builder.withPasswordLength(9)).build();
             });
         }
 
         @Test
         void builderWithPasswordLengthIs6() {
-            TOTPGenerator generator = new TOTPGenerator.Builder(secret.getBytes()).withHOTPGenerator(builder -> builder.withPasswordLength(6)).build();
+            TOTPGenerator generator = new TOTPGenerator.Builder(secret).withHOTPGenerator(builder -> builder.withPasswordLength(6)).build();
             int expected = 6;
 
             assertThat(generator.getPasswordLength(), Matchers.is(expected));
@@ -308,7 +308,7 @@ class TOTPGeneratorTest {
 
         @Test
         void builderWithAlgorithmSHA1() {
-            TOTPGenerator generator = new TOTPGenerator.Builder(secret.getBytes()).withHOTPGenerator(builder -> builder.withAlgorithm(HMACAlgorithm.SHA1)).build();
+            TOTPGenerator generator = new TOTPGenerator.Builder(secret).withHOTPGenerator(builder -> builder.withAlgorithm(HMACAlgorithm.SHA1)).build();
             HMACAlgorithm expected = HMACAlgorithm.SHA1;
 
             assertThat(generator.getAlgorithm(), Matchers.is(expected));
@@ -316,7 +316,7 @@ class TOTPGeneratorTest {
 
         @Test
         void builderWithAlgorithmSHA256() {
-            TOTPGenerator generator = new TOTPGenerator.Builder(secret.getBytes()).withHOTPGenerator(builder -> builder.withAlgorithm(HMACAlgorithm.SHA256)).build();
+            TOTPGenerator generator = new TOTPGenerator.Builder(secret).withHOTPGenerator(builder -> builder.withAlgorithm(HMACAlgorithm.SHA256)).build();
             HMACAlgorithm expected = HMACAlgorithm.SHA256;
 
             assertThat(generator.getAlgorithm(), Matchers.is(expected));
@@ -324,7 +324,7 @@ class TOTPGeneratorTest {
 
         @Test
         void builderWithAlgorithmSHA512() {
-            TOTPGenerator generator = new TOTPGenerator.Builder(secret.getBytes()).withHOTPGenerator(builder -> builder.withAlgorithm(HMACAlgorithm.SHA512)).build();
+            TOTPGenerator generator = new TOTPGenerator.Builder(secret).withHOTPGenerator(builder -> builder.withAlgorithm(HMACAlgorithm.SHA512)).build();
             HMACAlgorithm expected = HMACAlgorithm.SHA512;
 
             assertThat(generator.getAlgorithm(), Matchers.is(expected));
@@ -333,12 +333,12 @@ class TOTPGeneratorTest {
         @ParameterizedTest
         @ValueSource(ints = {1, 2, 3, 4, 5, 9, 10})
         void builderWithInvalidPasswordLength_throwsIllegalArgumentException(int passwordLength) {
-            assertThrows(IllegalArgumentException.class, () -> new TOTPGenerator.Builder(secret.getBytes()).withHOTPGenerator(builder -> builder.withPasswordLength(passwordLength)).build());
+            assertThrows(IllegalArgumentException.class, () -> new TOTPGenerator.Builder(secret).withHOTPGenerator(builder -> builder.withPasswordLength(passwordLength)).build());
         }
 
         @Test
         void builderWithoutPeriod_defaultPeriod() {
-            TOTPGenerator generator = new TOTPGenerator.Builder(secret.getBytes()).build();
+            TOTPGenerator generator = new TOTPGenerator.Builder(secret).build();
             Duration expected = Duration.ofSeconds(30);
 
             assertThat(generator.getPeriod(), is(expected));
@@ -346,7 +346,7 @@ class TOTPGeneratorTest {
 
         @Test
         void builderWithoutAlgorithm_defaultAlgorithm() {
-            TOTPGenerator generator = new TOTPGenerator.Builder(secret.getBytes()).build();
+            TOTPGenerator generator = new TOTPGenerator.Builder(secret).build();
             HMACAlgorithm expected = HMACAlgorithm.SHA1;
 
             assertThat(generator.getAlgorithm(), is(expected));


### PR DESCRIPTION
Addresses #83

* Adds `String secret` constructor
* Adds notes about secret being Base32-encoded to avoid confusion with the RFC-4226 shared secret
* Ensures that UTF-8 used for encoding/decoding (just in case; `String#getBytes()` uses standard charset)