### PR TITLE
Replace + with %20 to comply with URI spec

### DIFF
--- a/src/main/java/com/bastiaanjansen/otp/helpers/URIHelper.java
+++ b/src/main/java/com/bastiaanjansen/otp/helpers/URIHelper.java
@@ -73,9 +73,12 @@ public class URIHelper {
 
     public static String encode(String value) {
         try {
-            return URLEncoder.encode(value, StandardCharsets.UTF_8.toString());
+            // Standard URLEncoder uses + for spaces (application/x-www-form-urlencoded)
+            // We replace it with %20 to comply with URI spec (RFC 3986)
+            return URLEncoder.encode(value, StandardCharsets.UTF_8.name())
+                    .replace("+", "%20");
         } catch (UnsupportedEncodingException e) {
-            throw new IllegalArgumentException(e);
+            throw new RuntimeException(e.getMessage(), e);
         }
     }
 }

--- a/src/test/java/com/bastiaanjansen/otp/HOTPGeneratorTest.java
+++ b/src/test/java/com/bastiaanjansen/otp/HOTPGeneratorTest.java
@@ -119,7 +119,7 @@ class HOTPGeneratorTest {
 
         String url = generator.getURI(10, "issuer with space").toString();
 
-        assertThat(url, is("otpauth://hotp/issuer+with+space?digits=6&counter=10&secret=vv3kox7uqj4kyakohmzpph3us4cjimh6f3zknb5c2oobq6v2kiyhm27q&issuer=issuer+with+space&algorithm=SHA1"));
+        assertThat(url, is("otpauth://hotp/issuer%20with%20space?digits=6&counter=10&secret=vv3kox7uqj4kyakohmzpph3us4cjimh6f3zknb5c2oobq6v2kiyhm27q&issuer=issuer%20with%20space&algorithm=SHA1"));
     }
 
     @Test

--- a/src/test/java/com/bastiaanjansen/otp/helpers/URIHelperTest.java
+++ b/src/test/java/com/bastiaanjansen/otp/helpers/URIHelperTest.java
@@ -65,7 +65,7 @@ class URIHelperTest {
         query.put("test", "value 1");
         query.put("test2", "value?&2");
         URI uri = URIHelper.createURI("scheme", "host", "path", query);
-        String expected = "scheme://host/path?test2=value%3F%262&test=value+1";
+        String expected = "scheme://host/path?test2=value%3F%262&test=value%201";
 
         assertThat(uri.toString(), is(expected));
     }


### PR DESCRIPTION
This PR fixes an issue that in Microsoft Authenticator names with spaces get a `+` instead of spaces.
Root cause is that the scheme for OTP is to be URI encoded, not URL encoded.

See also https://github.com/BastiaanJansen/otp-java/issues/81