### PR TITLE
Add optional CounterStorage to prevent TOTP replay #69

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,36 @@ try {
 }
 ```
 
+#### Ensuring a code is only used once
+By default, `verify()` is stateless: a valid code is accepted every time it is verified within its time window. To make codes truly one-time, configure a counter storage, which keeps track of the last used counter. With a counter storage configured, `verify()` accepts a valid code only once.
+
+A counter storage is bound to a single identity, just like the secret. The built-in `InMemoryCounterStorage` is a shared backend which binds to an identifier (for example a user id) with `forIdentifier()`. Keep one instance for the whole application; `TOTPGenerator` instances are cheap and can be created per request:
+
+```java
+// One shared backend for the whole application
+private final InMemoryCounterStorage counterStorage = new InMemoryCounterStorage();
+
+boolean checkSecondFactor(User user, String code) {
+    TOTPGenerator totpGenerator = new TOTPGenerator.Builder(user.getTotpSecret())
+            .withCounterStorage(counterStorage.forIdentifier(user.getId()))
+            .build();
+
+    return totpGenerator.verify(code);
+}
+```
+
+The first call with a valid code returns true; verifying the same code again for the same identity returns false. Counters are monotonic: consuming a code also invalidates older, not yet used codes within the delay window.
+
+`InMemoryCounterStorage` keeps the last used counters in the memory of a single JVM. For distributed systems, where a code consumed on one node should not be accepted on another, implement the `CounterStorage` interface with a shared store such as Redis or Hazelcast, bound to the identity it verifies, for example `new RedisCounterStorage(pool, user.getId())`:
+
+```java
+public interface CounterStorage {
+    boolean markAsUsed(long counter);
+}
+```
+
+`markAsUsed` must atomically check whether the given counter is greater than the last used counter and, if so, store it as the new last used counter. Entries may safely expire after the delay window has passed.
+
 ### Generation of OTPAuth URI's
 To easily generate a OTPAuth URI for easy on-boarding, use the `getURI()` method for both `HOTP` and `TOTP`. Example for `TOTP`:
 ```java

--- a/src/main/java/com/bastiaanjansen/otp/CounterStorage.java
+++ b/src/main/java/com/bastiaanjansen/otp/CounterStorage.java
@@ -1,0 +1,25 @@
+package com.bastiaanjansen.otp;
+
+/**
+ * Stores the last used counter for a single identity, to prevent a one-time password from being used more than once.
+ * <p>
+ * A counter storage is bound to one identity (for example a user). When configured with
+ * {@link TOTPGenerator.Builder#withCounterStorage(CounterStorage)}, {@link TOTPGenerator#verify(String)} accepts a
+ * valid code only once. A built-in in-memory implementation is available via
+ * {@link InMemoryCounterStorage#forIdentifier(String)}. For distributed systems, implement this interface with a
+ * shared store such as Redis or Hazelcast, so a code consumed on one node cannot be replayed on another.
+ */
+public interface CounterStorage {
+
+    /**
+     * Atomically checks whether the given counter is greater than the last used counter and, if so, stores it as
+     * the new last used counter.
+     * <p>
+     * Implementations must perform the check and store as one atomic operation, so that two concurrent calls with
+     * the same counter cannot both return true.
+     *
+     * @param counter counter the one-time password was generated with
+     * @return true when the counter was not used before and is now marked as used, false when it was already used
+     */
+    boolean markAsUsed(long counter);
+}

--- a/src/main/java/com/bastiaanjansen/otp/InMemoryCounterStorage.java
+++ b/src/main/java/com/bastiaanjansen/otp/InMemoryCounterStorage.java
@@ -1,0 +1,42 @@
+package com.bastiaanjansen.otp;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ * Built-in in-memory backend for {@link CounterStorage}, keeping the last used counter per identifier.
+ * <p>
+ * Create one shared instance for the whole application and bind it to an identifier per verification with
+ * {@link #forIdentifier(String)}:
+ * <pre>{@code
+ * TOTPGenerator totpGenerator = new TOTPGenerator.Builder(secret)
+ *         .withCounterStorage(counterStorage.forIdentifier(userId))
+ *         .build();
+ * }</pre>
+ * Note: because counters are only kept in the memory of a single JVM, this implementation does not prevent replay
+ * across multiple application instances, and entries are kept for as long as this instance lives. For distributed
+ * systems, implement {@link CounterStorage} with a shared store such as Redis or Hazelcast.
+ */
+public class InMemoryCounterStorage {
+
+    private final ConcurrentMap<String, Long> lastUsedCounters = new ConcurrentHashMap<>();
+
+    /**
+     * Creates a counter storage bound to the given identifier, backed by this instance.
+     *
+     * @param identifier identifier to store the last used counter by, for example a user id
+     * @return counter storage bound to the identifier
+     */
+    public CounterStorage forIdentifier(final String identifier) {
+        return counter -> markAsUsed(identifier, counter);
+    }
+
+    private boolean markAsUsed(final String identifier, final long counter) {
+        while (true) {
+            Long lastUsed = lastUsedCounters.putIfAbsent(identifier, counter);
+            if (lastUsed == null) return true;
+            if (counter <= lastUsed) return false;
+            if (lastUsedCounters.replace(identifier, lastUsed, counter)) return true;
+        }
+    }
+}

--- a/src/main/java/com/bastiaanjansen/otp/TOTPGenerator.java
+++ b/src/main/java/com/bastiaanjansen/otp/TOTPGenerator.java
@@ -112,12 +112,14 @@ public final class TOTPGenerator {
     public boolean verify(final String code, final int delayWindow) {
         long counter = calculateCounter(clock, period);
 
-        if (counterStorage == null)
+        if (counterStorage == null) {
             return hotpGenerator.verify(code, counter, delayWindow);
+        }
 
         for (int i = -delayWindow; i <= delayWindow; i++) {
-            if (hotpGenerator.verify(code, counter + i))
+            if (hotpGenerator.verify(code, counter + i)) {
                 return counterStorage.markAsUsed(counter + i);
+            }
         }
 
         return false;

--- a/src/main/java/com/bastiaanjansen/otp/TOTPGenerator.java
+++ b/src/main/java/com/bastiaanjansen/otp/TOTPGenerator.java
@@ -23,11 +23,14 @@ public final class TOTPGenerator {
 
     private final Clock clock;
 
+    private final CounterStorage counterStorage;
+
     private final HOTPGenerator hotpGenerator;
 
     private TOTPGenerator(final Builder builder) {
         this.period = builder.period;
         this.clock = builder.clock;
+        this.counterStorage = builder.counterStorage;
         this.hotpGenerator = builder.hotpBuilder.build();
     }
 
@@ -95,12 +98,12 @@ public final class TOTPGenerator {
     }
 
     public boolean verify(final String code) {
-        long counter = calculateCounter(clock, period);
-        return hotpGenerator.verify(code, counter);
+        return verify(code, 0);
     }
 
     /**
-     * Checks whether a code is valid for a specific counter taking a delay window into account
+     * Checks whether a code is valid for a specific counter taking a delay window into account. When a
+     * {@link CounterStorage} is configured, a valid code is only accepted once
      *
      * @param code an OTP code
      * @param delayWindow window in which a code can still be deemed valid
@@ -108,7 +111,16 @@ public final class TOTPGenerator {
      */
     public boolean verify(final String code, final int delayWindow) {
         long counter = calculateCounter(clock, period);
-        return hotpGenerator.verify(code, counter, delayWindow);
+
+        if (counterStorage == null)
+            return hotpGenerator.verify(code, counter, delayWindow);
+
+        for (int i = -delayWindow; i <= delayWindow; i++) {
+            if (hotpGenerator.verify(code, counter + i))
+                return counterStorage.markAsUsed(counter + i);
+        }
+
+        return false;
     }
 
     public URI getURI(final String issuer) throws URISyntaxException {
@@ -170,6 +182,8 @@ public final class TOTPGenerator {
 
         private Clock clock;
 
+        private CounterStorage counterStorage;
+
         private final HOTPGenerator.Builder hotpBuilder;
 
         /**
@@ -202,6 +216,19 @@ public final class TOTPGenerator {
 
         public Builder withClock(Clock clock) {
             this.clock = clock;
+            return this;
+        }
+
+        /**
+         * Configures a counter storage which keeps track of the last used counter, so a valid code is only
+         * accepted once by {@link TOTPGenerator#verify(String)}. The storage is bound to a single identity
+         * (for example a user): use {@link InMemoryCounterStorage#forIdentifier(String)} or a custom
+         * implementation backed by a shared store for distributed systems.
+         *
+         * @param counterStorage counter storage to use
+         */
+        public Builder withCounterStorage(CounterStorage counterStorage) {
+            this.counterStorage = counterStorage;
             return this;
         }
 

--- a/src/test/java/com/bastiaanjansen/otp/InMemoryCounterStorageTest.java
+++ b/src/test/java/com/bastiaanjansen/otp/InMemoryCounterStorageTest.java
@@ -1,0 +1,79 @@
+package com.bastiaanjansen.otp;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+class InMemoryCounterStorageTest {
+
+    private InMemoryCounterStorage storage;
+
+    @BeforeEach
+    void setUp() {
+        storage = new InMemoryCounterStorage();
+    }
+
+    @Test
+    void markAsUsedFirstTime_true() {
+        assertThat(storage.forIdentifier("identifier").markAsUsed(100), is(true));
+    }
+
+    @Test
+    void markAsUsedTwice_false() {
+        storage.forIdentifier("identifier").markAsUsed(100);
+
+        assertThat(storage.forIdentifier("identifier").markAsUsed(100), is(false));
+    }
+
+    @Test
+    void markOlderCounterAsUsed_false() {
+        storage.forIdentifier("identifier").markAsUsed(100);
+
+        assertThat(storage.forIdentifier("identifier").markAsUsed(99), is(false));
+    }
+
+    @Test
+    void markNewerCounterAsUsed_true() {
+        storage.forIdentifier("identifier").markAsUsed(100);
+
+        assertThat(storage.forIdentifier("identifier").markAsUsed(101), is(true));
+    }
+
+    @Test
+    void markAsUsedWithDifferentIdentifier_true() {
+        storage.forIdentifier("identifier").markAsUsed(100);
+
+        assertThat(storage.forIdentifier("another-identifier").markAsUsed(100), is(true));
+    }
+
+    @Test
+    void markAsUsedConcurrently_onlyOneSucceeds() throws Exception {
+        int threads = 10;
+        ExecutorService executor = Executors.newFixedThreadPool(threads);
+
+        try {
+            List<Callable<Boolean>> tasks = IntStream.range(0, threads)
+                    .mapToObj(i -> (Callable<Boolean>) () -> storage.forIdentifier("identifier").markAsUsed(100))
+                    .collect(Collectors.toList());
+
+            long succeeded = 0;
+            for (Future<Boolean> future : executor.invokeAll(tasks)) {
+                if (future.get()) succeeded++;
+            }
+
+            assertThat(succeeded, is(1L));
+        } finally {
+            executor.shutdown();
+        }
+    }
+}

--- a/src/test/java/com/bastiaanjansen/otp/TOTPGeneratorTest.java
+++ b/src/test/java/com/bastiaanjansen/otp/TOTPGeneratorTest.java
@@ -151,6 +151,74 @@ class TOTPGeneratorTest {
         assertThat(generator.verify(code, 1), is(true));
     }
 
+    @Test
+    void verifyCodeWithCounterStorage_true() {
+        TOTPGenerator generator = new TOTPGenerator.Builder(secret)
+                .withCounterStorage(new InMemoryCounterStorage().forIdentifier("identifier"))
+                .build();
+        String code = generator.now();
+
+        assertThat(generator.verify(code), is(true));
+    }
+
+    @Test
+    void verifyCodeTwiceWithCounterStorage_false() {
+        TOTPGenerator generator = new TOTPGenerator.Builder(secret)
+                .withCounterStorage(new InMemoryCounterStorage().forIdentifier("identifier"))
+                .build();
+        String code = generator.now();
+        generator.verify(code);
+
+        assertThat(generator.verify(code), is(false));
+    }
+
+    @Test
+    void verifyCodeTwiceWithCounterStorageWithDifferentIdentifier_true() {
+        InMemoryCounterStorage counterStorage = new InMemoryCounterStorage();
+        TOTPGenerator generator = new TOTPGenerator.Builder(secret)
+                .withCounterStorage(counterStorage.forIdentifier("identifier"))
+                .build();
+        TOTPGenerator otherGenerator = new TOTPGenerator.Builder(secret)
+                .withCounterStorage(counterStorage.forIdentifier("another-identifier"))
+                .build();
+        String code = generator.now();
+        generator.verify(code);
+
+        assertThat(otherGenerator.verify(code), is(true));
+    }
+
+    @Test
+    void verifyInvalidCodeWithCounterStorage_false() {
+        TOTPGenerator generator = new TOTPGenerator.Builder(secret)
+                .withCounterStorage(new InMemoryCounterStorage().forIdentifier("identifier"))
+                .build();
+
+        assertThat(generator.verify("000000"), is(false));
+    }
+
+    @Test
+    void verifyOlderCodeTwiceWithCounterStorageWithDelayWindowIs1_false() {
+        TOTPGenerator generator = new TOTPGenerator.Builder(secret)
+                .withCounterStorage(new InMemoryCounterStorage().forIdentifier("identifier"))
+                .build();
+        String code = generator.at(Instant.now().minusSeconds(30));
+        generator.verify(code, 1);
+
+        assertThat(generator.verify(code, 1), is(false));
+    }
+
+    @Test
+    void verifyCurrentCodeAfterOlderCodeWithCounterStorage_true() {
+        TOTPGenerator generator = new TOTPGenerator.Builder(secret)
+                .withCounterStorage(new InMemoryCounterStorage().forIdentifier("identifier"))
+                .build();
+        String olderCode = generator.at(Instant.now().minusSeconds(30));
+        String currentCode = generator.now();
+        generator.verify(olderCode, 1);
+
+        assertThat(generator.verify(currentCode, 1), is(true));
+    }
+
 
     @Test
     void getURIWithIssuer() throws URISyntaxException {


### PR DESCRIPTION
Implements the counter storage proposed in #69, so TOTP codes can be truly one-time.

## What this adds

- A `CounterStorage` interface with a single method, `markAsUsed(long counter)`.
It atomically checks whether the given counter is greater than the last used counter and, if so, stores it.
A
storage instance is bound to a single identity (for example a user) — the same way a `TOTPGenerator` is bound to a single secret.
- A built-in `InMemoryCounterStorage`: one shared backend for the whole application, bound to an identity per verification with `forIdentifier(userId)`.
- `TOTPGenerator.Builder.withCounterStorage(...)`.
When configured, `verify()` accepts a valid code only once; when a code matches within the delay window, the matched counter is atomically
recorded and any replay is rejected.

## Usage

```java
// One shared backend for the whole application
private final InMemoryCounterStorage counterStorage = new InMemoryCounterStorage();

boolean checkSecondFactor(User user, String code) {
	TOTPGenerator totpGenerator = new TOTPGenerator.Builder(user.getTotpSecret())
		.withCounterStorage(counterStorage.forIdentifier(user.getId()))
		.build();

	return totpGenerator.verify(code);
}
```
For distributed systems, implement `CounterStorage` against a shared store such as Redis or Hazelcast (e.g. `new RedisCounterStorage(pool, user.getId())`), so a code consumed on one node cannot be replayed on another.
Entries may safely expire once outside the delay window.

## Design notes

- Fully backward compatible and opt-in: without a configured storage, `verify()` behaves exactly as before.
- The interface is a single atomic check-and-store rather than separate get/set methods, so two concurrent verifications (or two nodes) can never both accept the same code.
- Counters are monotonic per identity: consuming a code also invalidates older, not yet used codes within the delay window (in line with RFC 6238 §5.2).
- On a match within the delay window, the matched counter is stored — consuming a delayed code from the previous window does not block the current window's code.
Testing

- Replay rejection, per-identity isolation, delay-window replay, current-code-after-older-code, invalid codes.
- A concurrency test asserting that of 10 threads verifying the same code, exactly one succeeds.